### PR TITLE
feat: 🎸 Adding ability to reveal clip files in folder

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -156,3 +156,7 @@ ipcMain.handle('fetch-tags-like', (event, query) => {
 ipcMain.handle('open-files', (event, files) => {
     return Promise.all(files.map(file => shell.openPath(file.path)))
 })
+
+ipcMain.handle('open-in-folder', (event, files) => {
+    return Promise.all(files.map(file => shell.showItemInFolder(file.path)))
+})

--- a/src/renderer/components/clip/ClipCard/index.js
+++ b/src/renderer/components/clip/ClipCard/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react'
 import { useDispatch } from 'react-redux'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faEllipsisV, faPen, faTrash } from '@fortawesome/free-solid-svg-icons'
+import { faEllipsisV, faPen, faTrash, faFolder } from '@fortawesome/free-solid-svg-icons'
 import * as moment from 'moment'
 
 import { ClipCard } from '@paper-ui/clip'
@@ -16,7 +16,7 @@ import { Menu } from '@paper/components/overlay'
 import { useOnClickOutside } from '@paper/hooks'
 
 import { openEditClipModal, openDeleteClipPopup } from '@paper/store/clips/actions'
-import { openFiles } from '@paper/store/files/actions'
+import { openFiles, openInFolder } from '@paper/store/files/actions'
 
 export default ({
     id,
@@ -32,6 +32,11 @@ export default ({
     useOnClickOutside(menuRef, () => setIsMenuOpen(false))
 
     const menuItems = [
+        {
+            name: 'Open folder',
+            icon: faFolder,
+            handler: () => dispatch(openInFolder(files)),
+        },
         {
             name: 'Edit',
             icon: faPen,

--- a/src/renderer/store/files/actions.js
+++ b/src/renderer/store/files/actions.js
@@ -53,3 +53,29 @@ export const openFiles = files =>
             .then(payload => dispatch(openFilesSuccess(payload)))
             .catch(error => dispatch(openFilesFailure(error)))
     }
+
+export const OPEN_IN_FOLDER_REQUEST = 'OPEN_IN_FOLDER_REQUEST'
+export const OPEN_IN_FOLDER_SUCCESS = 'OPEN_IN_FOLDER_SUCCESS'
+export const OPEN_IN_FOLDER_FAILURE = 'OPEN_IN_FOLDER_FAILURE'
+
+export const openInFolderRequest = (payload) => ({
+    type: OPEN_IN_FOLDER_REQUEST,
+    payload,
+})
+
+export const openInFolderSuccess = (payload) => ({
+    type: OPEN_IN_FOLDER_SUCCESS,
+    payload,
+})
+
+export const openInFolderFailure = (payload) => ({
+    type: OPEN_IN_FOLDER_FAILURE,
+    payload,
+})
+
+export const openInFolder = files => dispatch => {
+    dispatch(openInFolderRequest())
+    return ipcRenderer.invoke('open-in-folder', files)
+        .then(payload => dispatch(openInFolderSuccess(payload)))
+        .catch(error => dispatch(openInFolderFailure(error)))
+}


### PR DESCRIPTION
This PR adds the 'Open in folder' in the clip menu. This option shows the given clip file or files in a file manager. If possible, it selects opened file.